### PR TITLE
Fix link and typo

### DIFF
--- a/_includes/paper.html
+++ b/_includes/paper.html
@@ -7,7 +7,7 @@
     {% endif %}
   </a>
   <div class="media-body"  >
-    {% if include.paper.selected %}<span class="glyphicon glyphicon-star" aria-hidden="true"></span> {% endif %}  <strong><a href="/papers/{{include.paper.id}}.html">{{ include.paper.title }}</a></strong><br/>
+    {% if include.paper.selected %}<span class="glyphicon glyphicon-star" aria-hidden="true"></span> {% endif %}  <strong><a href="{{site.deploy}}/papers/{{include.paper.id}}.html">{{ include.paper.title }}</a></strong><br/>
     {% if include.paper.authors %}{{ include.paper.authors }}.{% endif %}
     {% case include.paper.paper-type %}
       {% when "inproceedings" %}

--- a/_site/index.html
+++ b/_site/index.html
@@ -90,7 +90,7 @@
       </a> Google Scholar<br/>
        <a href="http://github.com/guzmanhe">
         <img src="img/ico/github_icon.png" alt=""/>
-      </a> Github 
+      </a> GitHub
 
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@ work:
       </a> Google Scholar<br/>{% endif %}
       {% if page.github.id %} <a href="http://github.com/{{ page.github.id }}">
         <img src="img/ico/github_icon.png" alt=""/>
-      </a> Github {% endif %}
+      </a> GitHub {% endif %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
The links for the papers are broken. They repeat the word `paper` in the URL twice and lead to a 404 page.

![](https://user-images.githubusercontent.com/32255369/96395827-34c7c100-11f8-11eb-8500-e574fb2df072.png)

![](https://user-images.githubusercontent.com/32255369/96395839-3d1ffc00-11f8-11eb-957c-f500baca6f90.png)

This pull request fixes the broken links and two typos.